### PR TITLE
Protect access to proberList with a mutex.

### DIFF
--- a/lib/proberlist/api.go
+++ b/lib/proberlist/api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Symantec/tricorder/go/tricorder"
 	"io"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -30,10 +31,11 @@ type proberType struct {
 
 // ProberList defines a type which manages a list of Probers.
 type ProberList struct {
-	probers               []*proberType
 	proberPath            string
 	probeStartTime        time.Time
 	probeTimeDistribution *tricorder.CumulativeDistribution
+	lock                  sync.Mutex
+	probers               []*proberType
 }
 
 // New returns a new ProberList. Only one should be created per application.


### PR DESCRIPTION
Doing this will allow us to safely register probers in separate
goroutines.